### PR TITLE
fix service account name

### DIFF
--- a/charts/pipeline-jenkins/templates/serviceaccount.yaml
+++ b/charts/pipeline-jenkins/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.rbac.serviceAccountName }}
+  name: {{ template "jenkins.fullname" . }}
   labels:
     app: {{ $serviceName }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"


### PR DESCRIPTION
chart does not work as is due to a mismatch in service account name in deployment yaml